### PR TITLE
fix(deployments): use artifact reg vars for images

### DIFF
--- a/terraform/modules/buyer/main.tf
+++ b/terraform/modules/buyer/main.tf
@@ -542,7 +542,10 @@ resource "kubectl_manifest" "app_gateways" {
 resource "kubectl_manifest" "app_deployments" {
   for_each = fileset(path.module, "manifests/app/deployments/**/*.yaml")
   yaml_body = templatefile("${path.module}/${each.value}", {
-    env_prefix = local.env_prefix
+    env_prefix = local.env_prefix,
+    project    = local.registry_project_id,
+    location   = local.registry_location,
+    repository = local.registry_repository,
   })
   force_conflicts = true
   force_new       = true

--- a/terraform/modules/buyer/manifests/app/deployments/bap-adapter-deployment.yaml
+++ b/terraform/modules/buyer/manifests/app/deployments/bap-adapter-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
         - name: bap-adapter
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/bap-adapter-service:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/bap-adapter-service:latest"
           env:
             - name: CONFIG
               value: "/config/config.json"

--- a/terraform/modules/buyer/manifests/app/deployments/bap-apis-deployment.yaml
+++ b/terraform/modules/buyer/manifests/app/deployments/bap-apis-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
         - name: bap-apis
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/bap-api:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/bap-api:latest"
           env:
             - name: CONFIG
               value: "/config/config.json"

--- a/terraform/modules/buyer/manifests/app/deployments/buyer-app-deployment.yaml
+++ b/terraform/modules/buyer/manifests/app/deployments/buyer-app-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
         - name: buyer-app
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/buyer-app-service"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/buyer-app-service"
           ports:
             - name: http
               port: 8080

--- a/terraform/modules/buyer/manifests/app/deployments/request-action-deployment.yaml
+++ b/terraform/modules/buyer/manifests/app/deployments/request-action-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
         - name: request-action
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/request-action-service:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/request-action-service:latest"
           env:
             - name: CONFIG
               value: "/config/config.json"

--- a/terraform/modules/buyer/manifests/mockup/gateway-service/deployment.yaml
+++ b/terraform/modules/buyer/manifests/mockup/gateway-service/deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: gateway-mockup
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/gateway-mockup:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/gateway-mockup:latest"
           resources:
             limits:
               memory: "128Mi"

--- a/terraform/modules/buyer/manifests/mockup/registry-service/deployment.yaml
+++ b/terraform/modules/buyer/manifests/mockup/registry-service/deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: "registry-mockup-sha256"
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/registry-mockup:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/registry-mockup:latest"
           resources:
             limits:
               memory: "256Mi"

--- a/terraform/modules/seller/main.tf
+++ b/terraform/modules/seller/main.tf
@@ -531,6 +531,9 @@ resource "kubectl_manifest" "app_deployments" {
   for_each = fileset(path.module, "manifests/app/deployments/**/*.yaml")
   yaml_body = templatefile("${path.module}/${each.value}", {
     env_prefix = local.env_prefix
+    project    = local.registry_project_id,
+    location   = local.registry_location,
+    repository = local.registry_repository,
   })
   force_conflicts = true
   force_new       = true

--- a/terraform/modules/seller/manifests/app/deployments/bpp-apis-deployment.yaml
+++ b/terraform/modules/seller/manifests/app/deployments/bpp-apis-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
         - name: bpp-apis
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/bpp-apis:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/bpp-apis:latest"
           env:
             - name: CONFIG
               value: "/config/config.json"

--- a/terraform/modules/seller/manifests/app/deployments/callback-action-deployment.yaml
+++ b/terraform/modules/seller/manifests/app/deployments/callback-action-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
         - name: callback-action
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/callback-action-service:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/callback-action-service:latest"
           env:
             - name: CONFIG
               value: "/config/config.json"

--- a/terraform/modules/seller/manifests/app/deployments/seller-adapter-deployment.yaml
+++ b/terraform/modules/seller/manifests/app/deployments/seller-adapter-deployment.yaml
@@ -34,7 +34,7 @@ spec:
         iam.gke.io/gke-metadata-server-enabled: "true"
       containers:
         - name: seller-adapter-service
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/seller-adapter-service:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/seller-adapter-service:latest"
           env:
             - name: CONFIG
               value: "/config/config.json"

--- a/terraform/modules/seller/manifests/mockup/registry-service/deployment.yaml
+++ b/terraform/modules/seller/manifests/mockup/registry-service/deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: registry-mockup
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/registry-mockup:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/registry-mockup:latest"
           resources:
             limits:
               memory: "256Mi"

--- a/terraform/modules/seller/manifests/mockup/seller-systems/deployment.yaml
+++ b/terraform/modules/seller/manifests/mockup/seller-systems/deployment.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
         - name: seller-systems
-          image: "asia-southeast1-docker.pkg.dev/bit-ondc/ondc-dev/seller-systems-service:latest"
+          image: "${location}-docker.pkg.dev/${project}/${repository}/seller-systems-service:latest"
           resources:
             limits:
               memory: "1024Mi"


### PR DESCRIPTION
Use Artifact Registry Variables for each deployment's image.

This alters based on an assumption that users keep all images in the same artifact registry.